### PR TITLE
Move API key to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.env

--- a/DigitalSoul/config.py
+++ b/DigitalSoul/config.py
@@ -1,7 +1,12 @@
 # Конфигурация проекта Digital Soul
 
 OLLAMA_URL = "http://localhost:11434/api/generate"
-OPENAI_API_KEY = "fake"
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "fake")
 OPENAI_MODEL = "gpt-4o"
 EMBEDDING_MODEL = "text-embedding-ada-002"
 FAISS_INDEX_PATH = "DigitalSoul/data/vector_memory.index"

--- a/DigitalSoul/requirements.txt
+++ b/DigitalSoul/requirements.txt
@@ -2,3 +2,4 @@ faiss-cpu
 openai
 requests
 numpy
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables in `DigitalSoul/config.py`
- ignore `.env` files
- list `python-dotenv` dependency
- provide `.env.example` with placeholder key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692bf043c0832281263284e442e2fb